### PR TITLE
UI Fixes for smaller viewports

### DIFF
--- a/components/dao-dashboard/index.js
+++ b/components/dao-dashboard/index.js
@@ -11,7 +11,9 @@ export function Dashboard({ proposals }) {
         position: 'relative',
         justifyContent: 'space-evenly',
         gap: '1rem',
-        margin: 'auto',
+        margin: '20px',
+        marginTop: '0px',
+        zIndex: '-1'
       }}
     >
       <Proposals proposals={proposals} />

--- a/components/dao-dashboard/layout/index.js
+++ b/components/dao-dashboard/layout/index.js
@@ -4,7 +4,7 @@ import { Box } from '../../../styles/elements'
 
 export default function DaoLayout({ heading, data, crowdsale, children, props }) {
   return (
-    <Layout heading={heading} data={data} {...props}>
+    <Layout heading={heading} {...props}>
       <Sidebar heading={heading} crowdsale={crowdsale} data={data} />
       <Box
         css={{

--- a/components/dao-dashboard/layout/sidebar/index.js
+++ b/components/dao-dashboard/layout/sidebar/index.js
@@ -3,11 +3,11 @@ import NewProposal from './NewProposal'
 import Menu from './Menu'
 import { Flex } from '../../../../styles/elements'
 
-export default function Sidebar({ crowdsale, heading, data }) {
+export default function Sidebar({ crowdsale, data }) {
   return (
     <Flex
       css={{
-        position: 'absolute',
+        position: 'fixed',
         top: 0,
         bottom: 0,
         left: 0,

--- a/components/dao-dashboard/proposal/post/ProposalCard.js
+++ b/components/dao-dashboard/proposal/post/ProposalCard.js
@@ -103,7 +103,6 @@ export const ProposalCard = ({ proposal }) => {
           <Flex
             gap="md"
             css={{
-              minWidth: '50rem',
               justifyContent: 'space-between',
               alignItems: 'center',
             }}

--- a/components/dao-dashboard/proposal/post/index.js
+++ b/components/dao-dashboard/proposal/post/index.js
@@ -23,7 +23,6 @@ export default function Proposals({ proposals }) {
             css={{
               position: 'relative',
               height: '96.18px',
-              border: '1px solid red',
               color: '#898888c2',
               border: '2px solid #737373ad',
               padding: '0.7rem',

--- a/components/home/NewDao.js
+++ b/components/home/NewDao.js
@@ -30,7 +30,7 @@ export default function NewDao() {
 
             '@media (max-width: 768px)': {
               fontSize: '18px',
-              minWidth: '25px',
+              // minWidth: '25px',
             },
           }}
         >

--- a/components/layout/Header.js
+++ b/components/layout/Header.js
@@ -26,18 +26,16 @@ export default function Header({ heading, props }) {
     <StyledHeader {...props}>
       <Flex
         css={{
-          position: 'relative',
-          // width: '100%',
-          width: '' + (heading === 'Decentra' ? '100%' : 'calc(100% - 297px)'),
+          position: 'fixed',
+          top: '0',
+          width: '' + (heading === 'Decentra' ? '95%' : 'calc(100% - 297px)'),
           height: '5rem',
           left: '' + (heading === 'Decentra' ? '0px' : '250px'),
-          // left: '250px',
           padding: '0px 1.5rem',
           justifyContent: 'space-between',
           alignItems: 'center',
-          gap: '5rem',
           '@media (max-width: 1040px)': {
-            justifyContent: 'flex-end',
+            justifyContent: 'space-between',
             margin: '0',
           },
         }}
@@ -49,7 +47,7 @@ export default function Header({ heading, props }) {
             css={{
               fontFamily: 'Screen',
               '@media (max-width: 1040px)': {
-                display: 'none',
+                // display: 'none',
               },
             }}
           >

--- a/components/layout/index.js
+++ b/components/layout/index.js
@@ -2,7 +2,7 @@ import Header from './Header'
 import Head from 'next/head'
 import { Box } from '../../styles/elements'
 
-export default function Layout({ heading, data, children, props }) {
+export default function Layout({ heading, children, props }) {
   return (
     <>
       <Box
@@ -16,7 +16,7 @@ export default function Layout({ heading, data, children, props }) {
           <title>{heading}</title>
           <meta property="og:title" content="My page title" key="title" />
         </Head>
-        <Header heading={heading} data={data} />
+        <Header heading={heading} />
         {children}
       </Box>
     </>


### PR DESCRIPTION
Fixes related to this issue: https://trello.com/c/WQ1TZQyN/7-modify-styling-of-elements-to-be-dynamic-instead-of-static-because-they-look-weird-when-the-window-is-made-smaller-or-on-mobile